### PR TITLE
Homepage assembly bug#14957

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/styles/partials/base/_state.scss
+++ b/src/styles/partials/base/_state.scss
@@ -2,16 +2,69 @@ a,
 button,
 a i,
 button i {
-	@include default-transition(color, background, border);
+  @include default-transition(color, background, border);
 }
 
-:focus,
-.focused {
-	outline: 2px solid $blue-lightest;
-	outline-offset: 3px;
+a {
+  &:focus {
+    outline: 2px solid $blue-lightest;
+    outline-offset: 3px;
+  }
+
+  &.focused {
+    outline: 2px solid $blue-lightest;
+    outline-offset: 3px;
+  }
+
+  i {
+    &:focus {
+      outline: 2px solid $blue-lightest;
+      outline-offset: 3px;
+    }
+
+    &.focused {
+      outline: 2px solid $blue-lightest;
+      outline-offset: 3px;
+    }
+  }
+}
+
+button {
+  &:focus {
+    outline: 2px solid $blue-lightest;
+    outline-offset: 3px;
+  }
+
+  &.focused {
+    outline: 2px solid $blue-lightest;
+    outline-offset: 3px;
+  }
+
+  i {
+    &:focus {
+      outline: 2px solid $blue-lightest;
+      outline-offset: 3px;
+    }
+
+    &.focused {
+      outline: 2px solid $blue-lightest;
+      outline-offset: 3px;
+    }
+  }
+}
+
+input {
+  &:focus {
+    outline: 2px solid $blue-lightest;
+    outline-offset: 3px;
+  }
+  &.focused {
+    outline: 2px solid $blue-lightest;
+    outline-offset: 3px;
+  }
 }
 
 :disabled,
 .disabled {
-	cursor: not-allowed;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
This addresses a bug on the home page, referenced in Bug #14957. Refactored the scss to include parents for the pseudo class `:focus`. Not having the element attached to a parent, causes a focused effect over `div` elements as well, when clicked. Thinking the `:disabled` element could potentially be refactored as well, but opening that up for feedback/ discussion first.