### PR TITLE
Google play icon bug#14961

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/styles/partials/components/_alt-list.scss
+++ b/src/styles/partials/components/_alt-list.scss
@@ -56,6 +56,8 @@
 
       i {
         @include list-icon;
+        text-align: left;
+        min-width: 32px;
       }
     }
   }


### PR DESCRIPTION
This addresses bug #14961 Google Play Icon Too Large. Looking at this item, the font size is set standard for icons in that position, at 2em. With this in mind, each icon's vertical height is coming in at 32px but each width is different, due to their respective shape. Google Play's width is naturally 32px and the Apple icon's width is 24px. If we were to set the width of the Google Play icon to 24px to match, the height would then be 24px as well, causing there to be a discrepancy in height. If we want a consistent solution without creating additional markup for exceptions, I suggest a modified method of the Font Awesome solution. This would entail adding a set width and text-align: left to the respective class, allowing the text following the icons to line up. I'm open to alternative ways to tackle this as well. My concern with adding a class for each item, is if down the road, we want to promote the download of an app elsewhere, and that new icon is a different size, then we're going to end up having to create an entirely new class.