### PR TITLE
Update icon heading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/components/basic/IconHeading.js
+++ b/src/components/basic/IconHeading.js
@@ -17,12 +17,13 @@ const IconHeading = props => {
   const { icon, image } = props;
   return (
     <div className="dg_icon-heading__container">
-      {icon && <i className={`${icon}`} aria-hidden="true"></i>}
-      {image && (
-        <div className="dg_icon-heading__image-container">
+      <span className="dg_icon-heading__icon">
+        {image ? (
           <img src={image} />
-        </div>
-      )}
+        ) : (
+          <i className={`${icon}`} aria-hidden="true"></i>
+        )}
+      </span>
       <Heading {...props} />
     </div>
   );

--- a/src/components/basic/IconHeading.md
+++ b/src/components/basic/IconHeading.md
@@ -34,7 +34,7 @@ Html Snippet:
 
 ```html
 <div class="dg_icon-heading__container">
-    <i class="fas fa-star" aria-hidden="true"></i>
+    <span class="dg_icon-heading__icon"><i class="fas fa-star" aria-hidden="true"></i></span>
     <h2 class="dg_icon-heading">Latest Headlines</h2>
 </div>
 ```
@@ -51,9 +51,7 @@ Html Snippet:
 
 ```html
 <div class="dg_icon-heading__container">
-    <div class="dg_icon-heading__image-container">
-        <img src="http://staging.baltimorecountymd.gov/sebin/h/i/seal-color-74.png">
-    </div>
+    <span class="dg_icon-heading__icon"><img src="//baltimorecountymd.gov/sebin/p/u/county-seal.svg"></span>
     <h2 class="dg_icon-heading">Latest Headlines</h2>
 </div>
 ```

--- a/src/dotgov.scss
+++ b/src/dotgov.scss
@@ -37,7 +37,6 @@
 @import "./styles/partials/components/alt-list";
 @import "./styles/partials/components/input";
 @import "./styles/partials/components/icon-heading";
-@import "./styles/partials/components/icon-heading-light";
 @import "./styles/partials/components/icon-heading-dark";
 @import "./styles/partials/components/checkbox";
 @import "./styles/partials/components/link";

--- a/src/styles/partials/components/_icon-heading-dark.scss
+++ b/src/styles/partials/components/_icon-heading-dark.scss
@@ -1,16 +1,8 @@
 .dg_section.dark {
-  .dg_icon-heading__container,
-  .dg_icon-heading__image-container {
-    background: none;
-
-    :before,
-    i:before {
-      background: $pale-blue;
-    }
-
-    :after,
-    i:after {
-      border-top-color: $pale-blue-lightest;
+  .dg_icon-heading__icon {
+    &:before,
+    &:after {
+      background-color: $pale-blue-lightest;
     }
   }
 }

--- a/src/styles/partials/components/_icon-heading-light.scss
+++ b/src/styles/partials/components/_icon-heading-light.scss
@@ -1,7 +1,0 @@
-.dg_section.light {
-    .dg_icon-heading__container {
-        i:before {
-            background: $gray-lightest;
-        }
-    }
-}

--- a/src/styles/partials/components/_icon-heading.scss
+++ b/src/styles/partials/components/_icon-heading.scss
@@ -18,8 +18,8 @@ $image-border-adjustment-margin: -$border-width-large * 3;
   margin-bottom: $default-margin;
 
   img {
-    max-width: 75px;
-    width: 100%;
+    height: 75px;
+    width: 75px;
   }
 
   &:before,

--- a/src/styles/partials/components/_icon-heading.scss
+++ b/src/styles/partials/components/_icon-heading.scss
@@ -6,91 +6,39 @@ $image-border-adjustment-margin: -$border-width-large * 3;
   margin-bottom: $margin-largest;
   text-align: center;
 
-  /* icon specific */
   i {
-    display: block;
     font-size: $icon-size;
-    margin-bottom: $default-margin;
-    z-index: 1;
+  }
+}
 
-    &:after {
-      z-index: -1;
-    }
+.dg_icon-heading__icon {
+  display: flex;
+  white-space: nowrap;
+  align-items: center;
+  margin-bottom: $default-margin;
+
+  img {
+    max-width: 75px;
+    width: 100%;
   }
 
-  /* image specific */
-  .dg_icon-heading__image-container {
-    position: relative;
-
-    &:before {
-      background: $white;
-      content: "";
-      margin: auto;
-
-      /* Position */
-      position: absolute;
-      left: 0;
-      right: 0;
-      z-index: 1;
-
-      /* Size */
-      height: $icon-image-size;
-      width: $icon-image-size + $padding-large * 2;
-    }
-
-    img {
-      margin-bottom: $image-border-adjustment-margin; /* TODO: not sure whats going on here */
-
-      /* Position */
-      position: relative;
-      z-index: 1;
-
-      /* Size */
-      height: $icon-image-size;
-    }
+  &:before,
+  &:after {
+    content: "";
+    height: 5px;
+    width: 100%;
+    background-color: $gray-light;
+    display: inline-block;
   }
 
-  /* shared */
-  i:before,
-  .dg_icon-heading__image-container {
-    background: $white;
-    padding: 0 $padding-large;
+  $icon-spacing: 20px;
+
+  &:before {
+    margin: 10px $icon-spacing 10px 0;
   }
 
-  i:before,
-  .dg_icon-heading__image-container img {
-    &:before {
-      position: relative;
-      z-index: 1;
-    }
-  }
-
-  i,
-  .dg_icon-heading__image-container {
-    position: relative;
-
-    &:after {
-      border-top: $border-width-large solid $gray-light;
-      content: "";
-
-      margin: 0 auto;
-
-      /* Position */
-      /* this centers the line to the full width specified */
-      position: absolute;
-      /* positioning must be absolute here, and relative positioning must be applied to the parent */
-      left: 0;
-      right: 0;
-      top: 50%;
-      bottom: 0;
-
-      /* Size */
-      width: 100%;
-    }
-  }
-
-  .dg_icon-heading__image-container {
-    margin-bottom: $default-margin - $image-border-adjustment-margin; /* account for border adjustment */
+  &:after {
+    margin: 10px 0 10px $icon-spacing;
   }
 }
 
@@ -101,16 +49,4 @@ $image-border-adjustment-margin: -$border-width-large * 3;
   letter-spacing: $base-spacing-unit * 3;
   line-height: 29px; /* Manually calculated for this element in the browser */
   padding: 0 !important; /* overrides default h2 in a dark section */
-}
-
-@media screen and (max-width: $medium-breakpoint) {
-  .dg_icon-heading__container {
-    margin-bottom: $margin-largest / 2 - 5; /* split the largest margin in half and subtract the line height difference */
-  }
-}
-
-@media screen and (max-width: $small-breakpoint) {
-  .dg_icon-heading {
-    letter-spacing: 10px;
-  }
 }


### PR DESCRIPTION
As a result of #161 we discovered that the icon heading did not support sections with an image as a background.

This is an attempt to fix the styles to work regardless of a the background of the container element.