### PR TITLE
Add IE Hacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.40",
+  "version": "0.1.52",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8447,7 +8447,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8468,12 +8469,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8488,17 +8491,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8615,7 +8621,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8627,6 +8634,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8641,6 +8649,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8648,12 +8657,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8672,6 +8683,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8752,7 +8764,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8764,6 +8777,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8849,7 +8863,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8885,6 +8900,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8904,6 +8920,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8947,12 +8964,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/dotgov.scss
+++ b/src/dotgov.scss
@@ -67,6 +67,9 @@
 @import "./styles/partials/template/subpage";
 @import "./styles/partials/template/sidebar";
 
+/** overrides */
+@import "./styles/overrides/ie-hacks";
+
 * {
   box-sizing: border-box;
 }

--- a/src/styles/overrides/_ie-hacks.scss
+++ b/src/styles/overrides/_ie-hacks.scss
@@ -1,0 +1,6 @@
+/*
+    Target IE10 && IE11 based on  https://stackoverflow.com/a/22788131/1143670.
+    All Styles for these browsers must be included in the following media query.
+*/
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+}

--- a/src/styles/overrides/_ie-hacks.scss
+++ b/src/styles/overrides/_ie-hacks.scss
@@ -16,7 +16,6 @@
     IE11 does not support object fill, which makes this background image very distorted.
     It was a design decision to remove from IE in order to make the display more appealing.
   */
-
   .dg_section__background-image,
   .dg_page-header__backgroundImage {
     display: none;

--- a/src/styles/overrides/_ie-hacks.scss
+++ b/src/styles/overrides/_ie-hacks.scss
@@ -16,7 +16,8 @@
     IE11 does not support object fill, which makes this background image very distorted.
     It was a design decision to remove from IE in order to make the display more appealing.
   */
-  .dg_section__background-image {
+  .dg_section__background-image,
+  .dg_page-header__backgroundImage {
     display: none;
   }
 }

--- a/src/styles/overrides/_ie-hacks.scss
+++ b/src/styles/overrides/_ie-hacks.scss
@@ -16,8 +16,14 @@
     IE11 does not support object fill, which makes this background image very distorted.
     It was a design decision to remove from IE in order to make the display more appealing.
   */
+
   .dg_section__background-image,
   .dg_page-header__backgroundImage {
     display: none;
+  }
+
+  .dg_page-header.blue:after,
+  .dg_section.dark {
+    background: $pale-blue;
   }
 }

--- a/src/styles/overrides/_ie-hacks.scss
+++ b/src/styles/overrides/_ie-hacks.scss
@@ -3,4 +3,12 @@
     All Styles for these browsers must be included in the following media query.
 */
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  /*
+        This class enables us to flex items at equal heights, but does not work with IE11.
+        In this case, we set the display to static which will cause the elements to not show equal height,
+        but will otherwise display as expected.
+    */
+  .d-lg-flex {
+    display: block !important;
+  }
 }

--- a/src/styles/overrides/_ie-hacks.scss
+++ b/src/styles/overrides/_ie-hacks.scss
@@ -4,11 +4,19 @@
 */
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   /*
-        This class enables us to flex items at equal heights, but does not work with IE11.
-        In this case, we set the display to static which will cause the elements to not show equal height,
-        but will otherwise display as expected.
-    */
+    This class enables us to flex items at equal heights, but does not work with IE11.
+    In this case, we set the display to static which will cause the elements to not show equal height,
+    but will otherwise display as expected.
+  */
   .d-lg-flex {
     display: block !important;
+  }
+
+  /*
+    IE11 does not support object fill, which makes this background image very distorted.
+    It was a design decision to remove from IE in order to make the display more appealing.
+  */
+  .dg_section__background-image {
+    display: none;
   }
 }

--- a/src/styles/partials/components/_date-news-card.scss
+++ b/src/styles/partials/components/_date-news-card.scss
@@ -3,7 +3,6 @@
   display: block;
   padding: $padding-larger;
   text-decoration: none;
-  min-height: 100%;
 
   p {
     margin-bottom: 0;
@@ -85,7 +84,6 @@
 
 @media screen and (max-width: $extra-large-breakpoint) {
   .dg_date-news-card {
-    min-height: auto;
     margin-bottom: $margin-large;
   }
 }

--- a/src/styles/partials/components/_page-header.scss
+++ b/src/styles/partials/components/_page-header.scss
@@ -84,9 +84,10 @@
 }
 
 @media screen and (max-width: $medium-breakpoint) {
-  .dg_page-header {
+  .dg_page-header.blue:after {
     background: $pale-blue;
   }
+
   .dg_page-header__backgroundImage {
     display: none;
   }


### PR DESCRIPTION
- Added way to hack IE browser, should not impact Edge
- Hide cover images for `section` and `page header` in ie per design team
- Fixed bad selector for page header background