### PR TITLE
Took class out of media query for Edge access

### DIFF
--- a/src/styles/overrides/_ie-hacks.scss
+++ b/src/styles/overrides/_ie-hacks.scss
@@ -25,8 +25,9 @@
   .dg_section.dark {
     background: $pale-blue;
   }
+}
 
-  .ms-focus-within {
-    @include default-focus-state;
-  }
+/* This wont work in Edge unless its outside of this query*/
+.ms-focus-within {
+  @include default-focus-state;
 }


### PR DESCRIPTION
Had to pull this outside of the media query to work in Edge. Why doesn't it work in Edge but in IE11 of all things.....magic!!!!!!!!