### PR TITLE
Use the site js instead of individual scripts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export {
 export { default as Alert } from "./components/basic/Alert";
 export {
   default as Accordion
-} from "./components/site/Accordion"; /** This should to the default components part of the project */
+} from "./components/basic/Accordion"; /** This should to the default components part of the project */
 export { default as StepList } from "./components/basic/StepList";
 export { default as StepListItem } from "./components/basic/StepListItem";
 export { default as Button } from "./components/basic/Button";

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -67,13 +67,7 @@ module.exports = {
           src: "https://kit.fontawesome.com/2475edd293.js"
         },
         {
-          src: "//baltimorecountymd.gov/sebin/t/i/dotgov-accordion.min.js"
-        },
-        {
-          src: "//baltimorecountymd.gov/sebin/r/z/dotgov-steplist.min.js"
-        },
-        {
-          src: "http://baltimorecountymd.gov/sebin/d/n/dotgov-modal.min.js"
+          src: "//baltimorecountymd.gov/sebin/z/l/dotgov-site.min.js"
         }
       ]
     }


### PR DESCRIPTION
Uses site js which includes all site specific js, instead of individually referencing them.