### PR TITLE
removed focus outline for static step lists

### DIFF
--- a/src/styles/partials/components/_step-list-dark.scss
+++ b/src/styles/partials/components/_step-list-dark.scss
@@ -23,9 +23,6 @@
   .dg_step-list.static {
     .dg_step-list__toggle-btn {
       cursor: default;
-      &:focus {
-        outline: none;
-      }
     }
 
     .dg_step-list__toggle-btn__title {

--- a/src/styles/partials/components/_step-list-dark.scss
+++ b/src/styles/partials/components/_step-list-dark.scss
@@ -23,10 +23,13 @@
   .dg_step-list.static {
     .dg_step-list__toggle-btn {
       cursor: default;
+      &:focus {
+        outline: none;
+      }
     }
 
     .dg_step-list__toggle-btn__title {
-        color: $white;
+      color: $white;
     }
 
     .dg_step-list__toggle-btn__btn-text,

--- a/src/styles/partials/components/_step-list.scss
+++ b/src/styles/partials/components/_step-list.scss
@@ -106,6 +106,9 @@
 .dg_step-list.static {
   .dg_step-list__toggle-btn {
     cursor: default;
+    &:focus {
+      outline: none;
+    }
   }
 
   .dg_step-list__toggle-btn__title {


### PR DESCRIPTION
Takes care of 15220 Static Step List should not allow for focus in TFS

Removes the focus around a static step list if tabbed or clicked.