### PR TITLE
Changed vertical-align property.

### DIFF
--- a/src/styles/partials/components/_breadcrumbs.scss
+++ b/src/styles/partials/components/_breadcrumbs.scss
@@ -54,7 +54,7 @@ $breadcrumb-icon-size: 20px;
         font-weight: $font-bold;
         content: $icon-home;
         font-family: $font-awesome-pro;
-        vertical-align: middle;
+        vertical-align: baseline;
         right: 10px;
       }
     }


### PR DESCRIPTION
@martypowell Minor one-line change to address the [bug](https://oittfs.bcg.ad.bcgov.us/BAUCollection/BaltimoreCounty.Gov%20Website/_workitems/edit/15540?src=WorkItemMention&src-action=artifact_link) logged by @sdurphy . Changed the vertical alignment of the home icon from middle to baseline.