### PR TITLE
Header text update14906

### DIFF
--- a/src/components/site/PageHeader.js
+++ b/src/components/site/PageHeader.js
@@ -35,10 +35,12 @@ const PageHeader = props => {
           )}
           <div className="row">
             <div className="col-12 col-lg-5 col-xl-6">
-              {preTitle && (
-                <span className="dg_page-header__pre-title">{preTitle}</span>
-              )}
-              <span className="dg_page-header__title">{title} </span>
+              <h1>
+                {preTitle && (
+                  <span className="dg_page-header__pre-title">{preTitle}</span>
+                )}
+                <span className="dg_page-header__title">{title} </span>
+              </h1>
             </div>
             <div className="col-12 col-lg-7 col-xl-6">
               {deck && <p className="dg_page-header__deck">{deck}</p>}

--- a/src/components/site/PageHeader.md
+++ b/src/components/site/PageHeader.md
@@ -68,8 +68,10 @@ Html Snippet:
       </div>
       <div class="row">
         <div class="col-12 col-lg-5 col-xl-6">
-          <span class="dg_page-header__pre-title">Department Of</span>
-          <span class="dg_page-header__title">Public Works </span>
+          <h1>
+            <span class="dg_page-header__pre-title">Department Of</span>
+            <span class="dg_page-header__title">Public Works </span>
+          </h1>
         </div>
         <div class="col-12 col-lg-7 col-xl-6">
           <p class="dg_page-header__deck">

--- a/src/styles/partials/components/_page-header-dark.scss
+++ b/src/styles/partials/components/_page-header-dark.scss
@@ -2,6 +2,10 @@
 .dg_page-header.blue {
   color: $white;
 
+  h1 {
+    color: $white;
+  }
+
   .dg_page-header__deck {
     color: $white;
   }


### PR DESCRIPTION
Three changes to address updated formatting when creating the SE template for [User Story 14906](https://oittfs.bcg.ad.bcgov.us/BAUCollection/BaltimoreCounty.Gov%20Website/_workitems/edit/14906).

1. In the original markup, the headline was wrapped in two parts by two span classes. I wrapped the span classes in an `h1`, since the copy that resides here will ultimately be the title of the page and should be reflected as such. With this, I have updated the react component to match.

2. Updated the .md file for consistency.

3. When wrapping the copy in the `h1`, the text reverted to the standard `h1` color of `black`. I corrected this by adding a style so it would be set to white within the dark background of the container.