### PR TITLE
Removed stray :after. Added :focus pseudo element.

### DIFF
--- a/src/styles/partials/components/_breadcrumbs.scss
+++ b/src/styles/partials/components/_breadcrumbs.scss
@@ -14,10 +14,6 @@ $breadcrumb-icon-size: 20px;
     margin: 0 $default-margin;
     text-decoration: none;
 
-    :after {
-      display: inline-block;
-    }
-
     &:first-child {
       margin-left: 0;
     }
@@ -30,6 +26,10 @@ $breadcrumb-icon-size: 20px;
       @include icon-content($icon-arrow-right);
       vertical-align: middle;
       right: -20px;
+    }
+
+    &:focus {
+      display: inline-block;
     }
 
     &:last-child {


### PR DESCRIPTION
@martypowell  @sdurphy Addresses bug "Breadcrumb Focus Outline Browser Differences" 

Two minor changes, one of which is more of a "housekeeping" item.

1. Added :`focus` pseudo-element to the `.breadcrumb `class, with the property `inline-block`. This allows the border to wrap around the link text in an even square, eliminating the odd shape observed previously, on tab focus.

2. Removed the orphan `:after` pseudo-element on line 17.