### PR TITLE
Fix classes for initial state Collapse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/components/basic/AccordionPanel.js
+++ b/src/components/basic/AccordionPanel.js
@@ -2,24 +2,20 @@ import React from "react";
 import classNames from "classnames";
 
 const AccordionPanel = props => {
-  const {
-    id,
-    header,
-    children,
-    subHeader,
-    className,
-    isExpanded = false
-  } = props;
-  const cssClasses = classNames(
+  const { id, header, children, subHeader, className, isExpanded } = props;
+  const panelCssClasses = classNames(
     "dg_accordion__collapsible",
-    "collapsed",
-    isExpanded ? "show" : null,
+    isExpanded ? null : "collapsed",
     className
+  );
+  const contentCssClasses = classNames(
+    "multi-collapse collapse",
+    isExpanded ? "show" : null
   );
   const buttonId = `accordion-btn-${id}`;
 
   return (
-    <div className={cssClasses}>
+    <div className={panelCssClasses}>
       <button
         className="dg_accordion-btn"
         type="button"
@@ -32,7 +28,7 @@ const AccordionPanel = props => {
         )}
       </button>
       <div
-        className="multi-collapse collapse"
+        className={contentCssClasses}
         aria-labelledby={buttonId}
         aria-expanded={isExpanded}
       >

--- a/src/components/basic/Collapse.md
+++ b/src/components/basic/Collapse.md
@@ -1,5 +1,7 @@
+### Default (Expanded)
+
 ```jsx
-<Collapse id="sample-collapse" header="Categories">
+<Collapse id="sample-collapse" header="Default Example">
   <p>Some really compelling content goes here.</p>
 </Collapse>
 ```
@@ -14,12 +16,42 @@ Html Snippet:
     id="accordion-btn-sample-collapse"
     aria-expanded="true"
   >
-    <span class="dg_accordion_buttontext-holder">Categories</span>
+    <span class="dg_accordion_buttontext-holder">Default Example</span>
   </button>
   <div
     class="multi-collapse collapse show"
-    aria-labeledby="accordion-btn-sample-collapse"
+    aria-labelledby="accordion-btn-sample-collapse"
     aria-expanded="true"
+  >
+    <div class="dg_accordion-item-body">
+      <p>Some really compelling content goes here.</p>
+    </div>
+  </div>
+</div>
+```
+
+### Collapsed by Default
+
+```jsx
+<Collapse id="sample-collapse" header="Categories" isExpanded={false}>
+  <p>Some really compelling content goes here.</p>
+</Collapse>
+```
+
+```html
+<div class="dg_accordion__collapsible collapsed dg_collapse">
+  <button
+    class="dg_accordion-btn"
+    type="button"
+    id="accordion-btn-sample-collapse"
+    aria-expanded="false"
+  >
+    <span class="dg_accordion_buttontext-holder">Categories</span>
+  </button>
+  <div
+    class="multi-collapse collapse"
+    aria-labelledby="accordion-btn-sample-collapse"
+    aria-expanded="false"
   >
     <div class="dg_accordion-item-body">
       <p>Some really compelling content goes here.</p>


### PR DESCRIPTION
Collapse jsut uses the Accordion Panel, so the changes were made there.

Basically matches up the classes in the dotgov js project to this project. Added both examples to the style guide under the collapse section.