### PR TITLE
Fixed casing for breadcrumb item

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,2 +1,0 @@
-exclude:
-- /*.js # root js files are config files

--- a/src/components/site/BreadCrumbLinkItem.js
+++ b/src/components/site/BreadCrumbLinkItem.js
@@ -1,8 +1,8 @@
-import React from "react";
 import PropTypes from "prop-types";
+import React from "react";
 import classnames from "classnames";
 
-const BreadcrumbLinkItem = props => {
+const BreadCrumbLinkItem = props => {
   const { link, text, className } = props;
   const BreadcrumbClasses = classnames("breadcrumb", className);
   return (
@@ -12,11 +12,11 @@ const BreadcrumbLinkItem = props => {
   );
 };
 
-BreadcrumbLinkItem.propTypes = {
+BreadCrumbLinkItem.propTypes = {
   /** The link or href for the a tag */
   link: PropTypes.string,
   /** The copy that exists inside the a tag */
   text: PropTypes.string.isRequired
 };
 
-export default BreadcrumbLinkItem;
+export default BreadCrumbLinkItem;

--- a/src/components/site/Breadcrumb.test.js
+++ b/src/components/site/Breadcrumb.test.js
@@ -1,14 +1,14 @@
+import BreadCrumbLinkItem from "./BreadCrumbLinkItem";
+import Breadcrumbs from "./Breadcrumbs";
 import React from "react";
 import ReactDOM from "react-dom";
-import Breadcrumbs from "./Breadcrumbs";
-import BreadcrumbLinkItem from "./BreadCrumbLinkItem";
 
 it("renders without crashing", () => {
   const div = document.createElement("div");
   ReactDOM.render(
     <Breadcrumbs>
-      <BreadcrumbLinkItem text="Departments" link="#" />
-      <BreadcrumbLinkItem text="Adoptable Pets" link="#" />
+      <BreadCrumbLinkItem text="Departments" link="#" />
+      <BreadCrumbLinkItem text="Adoptable Pets" link="#" />
     </Breadcrumbs>,
     div
   );

--- a/src/components/site/Breadcrumbs.md
+++ b/src/components/site/Breadcrumbs.md
@@ -2,16 +2,16 @@
 
 ```jsx
 import Section from "../basic/containers/Section";
-import BreadcrumbLinkItem from "./BreadcrumbLinkitem";
+import BreadCrumbLinkItem from "./BreadCrumbLinkItem";
 
 <Section>
   <Breadcrumbs>
-    <BreadcrumbLinkItem text="Departments" link="/departments/health" />
-    <BreadcrumbLinkItem
+    <BreadCrumbLinkItem text="Departments" link="/departments/health" />
+    <BreadCrumbLinkItem
       text="Department of Health"
       link="/departments/health"
     />
-    <BreadcrumbLinkItem
+    <BreadCrumbLinkItem
       className="breadcrumb-last"
       text="Adoptable Pets"
       link="/departments/health"
@@ -46,17 +46,17 @@ Html Snippet:
 
 ```jsx
 import Section from "../basic/containers/Section";
-import BreadcrumbLinkItem from "./BreadcrumbLinkitem";
+import BreadCrumbLinkItem from "./BreadCrumbLinkItem";
 
 <Section className="dark">
   <div style={{ padding: "15px" }}>
     <Breadcrumbs>
-      <BreadcrumbLinkItem text="Departments" link="/departments" />
-      <BreadcrumbLinkItem
+      <BreadCrumbLinkItem text="Departments" link="/departments" />
+      <BreadCrumbLinkItem
         text="Department of Health"
         link="/departments/health"
       />
-      <BreadcrumbLinkItem
+      <BreadCrumbLinkItem
         className="breadcrumb-last"
         text="Adoptable Pets"
         link="/departments/health"

--- a/src/components/site/PageHeader.md
+++ b/src/components/site/PageHeader.md
@@ -2,21 +2,21 @@
 
 ```jsx
 import Breadcrumbs from "./Breadcrumbs";
-import BreadcrumbLinkItem from "./BreadcrumbLinkitem";
+import BreadCrumbLinkItem from "./BreadCrumbLinkItem";
 
 const breadCrumbs = () => (
   <Breadcrumbs>
-    <BreadcrumbLinkItem
+    <BreadCrumbLinkItem
       text="Departments"
       title="This is a title"
       link="/departments"
     />
-    <BreadcrumbLinkItem
+    <BreadCrumbLinkItem
       text="Department of Health"
       title="This is a title"
       link="/departments/health"
     />
-    <BreadcrumbLinkItem
+    <BreadCrumbLinkItem
       className="breadcrumb-last"
       text="Adoptable Pets"
       link="/departments/health"

--- a/src/components/site/PageHeader.test.js
+++ b/src/components/site/PageHeader.test.js
@@ -1,8 +1,8 @@
+import BreadCrumbLinkItem from "./BreadCrumbLinkItem";
+import Breadcrumbs from "./Breadcrumbs";
+import PageHeader from "./PageHeader";
 import React from "react";
 import ReactDOM from "react-dom";
-import PageHeader from "./PageHeader";
-import Breadcrumbs from "./Breadcrumbs";
-import BreadcrumbLinkItem from "./BreadCrumbLinkItem";
 
 it("renders without crashing", () => {
   const div = document.createElement("div");
@@ -20,17 +20,17 @@ it("renders without crashing", () => {
 it("renders with breadcrumbs without crashing", () => {
   const breadCrumbs = () => (
     <Breadcrumbs>
-      <BreadcrumbLinkItem
+      <BreadCrumbLinkItem
         text="Departments"
         title="This is a title"
         link="/departments"
       />
-      <BreadcrumbLinkItem
+      <BreadCrumbLinkItem
         text="Department of Health"
         title="This is a title"
         link="/departments/health"
       />
-      <BreadcrumbLinkItem
+      <BreadCrumbLinkItem
         className="breadcrumb-last"
         text="Adoptable Pets"
         link="/departments/health"

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export { default as PageHeader } from "./components/site/PageHeader";
 export { default as SummaryList } from "./components/site/SummaryList";
 export { default as Breadcrumbs } from "./components/site/Breadcrumbs";
 export { default as SideBarSection } from "./components/site/SideBarSection";
-export { default as BreadcrumbLinkItem } from "./components/site/BreadCrumbLinkItem";
+export { default as BreadCrumbLinkItem } from "./components/site/BreadCrumbLinkItem";
 
 /** Other */
 export { default as Alert } from "./components/basic/Alert";


### PR DESCRIPTION
Casing in imports was causing Now to fail in this build.

These changes ensure they are consistent.

Update this change also removes better code hub from the build, since we aren't using it.