### PR TITLE
Override Site Executive Form Defaults

### DIFF
--- a/src/dotgov.scss
+++ b/src/dotgov.scss
@@ -88,6 +88,7 @@
 
 /** overrides */
 @import "./styles/overrides/ie-hacks";
+@import "./styles/overrides/se-form";
 
 * {
   box-sizing: border-box;

--- a/src/styles/overrides/_se-form.scss
+++ b/src/styles/overrides/_se-form.scss
@@ -32,10 +32,10 @@
       .seLabelCell {
         @extend .dg_label;
         margin-top: 0;
-        margin-bottom: 5px;
+        margin-bottom: $margin-smallest;
 
         .seRequiredMarker {
-          margin-left: 5px;
+          margin-left: $margin-smallest;
         }
       }
 
@@ -50,7 +50,7 @@
     .seRequiredMarker {
       color: $red;
       font-size: 0;
-      font-weight: 600;
+      font-weight: $font-medium;
       position: relative;
       visibility: hidden;
 

--- a/src/styles/overrides/_se-form.scss
+++ b/src/styles/overrides/_se-form.scss
@@ -1,0 +1,3 @@
+form .seText label {
+  @extend .dg_label;
+}

--- a/src/styles/overrides/_se-form.scss
+++ b/src/styles/overrides/_se-form.scss
@@ -1,3 +1,13 @@
-form .seText label {
-  @extend .dg_label;
+.seform {
+  form .seText label {
+    @extend .dg_label;
+  }
+
+  form fieldset {
+    @extend .dg_fieldset;
+
+    legend {
+      @extend .dg_legend;
+    }
+  }
 }

--- a/src/styles/overrides/_se-form.scss
+++ b/src/styles/overrides/_se-form.scss
@@ -29,17 +29,64 @@
         @extend .dg_checkbox-input;
       }
 
-      input[type="submit"] {
-        @extend .dg_button;
+      .seLabelCell {
+        @extend .dg_label;
+        margin-top: 0;
+        margin-bottom: 5px;
+
+        .seRequiredMarker {
+          margin-left: 5px;
+        }
       }
 
-      input[type="reset"] {
-        @extend .dg_button-link;
+      .SEAFGroupHorizontal,
+      .SEAFLabelHorizontal,
+      .SEAFGroupVertical,
+      .SEAFLabelVertical {
+        margin-bottom: $default-margin;
       }
     }
 
-    .seLabelCell {
-      @extend .dg_fieldset-hint;
+    .seRequiredMarker {
+      color: $red;
+      font-size: 0;
+      font-weight: 600;
+      position: relative;
+      visibility: hidden;
+
+      &:after {
+        @include icon-content($icon-asterisk);
+        font-size: $smallest-heading-font-size;
+        visibility: visible;
+      }
     }
   }
+
+  .SEAFGroupHorizontal,
+  .seFieldCellHorizontal,
+  .seLabelCellHorizontal,
+  .SEAFLabelHorizontal {
+    display: block;
+    vertical-align: auto;
+  }
+
+  .SEAFGroupVertical,
+  .seFieldCellVertical,
+  .seLabelCellVertical,
+  .SEAFLabelVertical {
+    display: block;
+  }
+
+  input[type="submit"] {
+    @extend .dg_button;
+  }
+
+  input[type="reset"] {
+    @extend .dg_button-link;
+  }
+}
+
+.SEAFWrapper > .seText > div > span {
+  display: block;
+  margin-bottom: $default-margin;
 }

--- a/src/styles/overrides/_se-form.scss
+++ b/src/styles/overrides/_se-form.scss
@@ -1,13 +1,45 @@
 .seform {
-  form .seText label {
-    @extend .dg_label;
-  }
+  form {
+    .seText label {
+      @extend .dg_label;
+    }
 
-  form fieldset {
-    @extend .dg_fieldset;
+    fieldset {
+      @extend .dg_fieldset;
 
-    legend {
-      @extend .dg_legend;
+      legend {
+        @extend .dg_legend;
+      }
+
+      .seRadioLabel {
+        @extend .dg_label;
+        @extend .dg_radio-label;
+      }
+
+      .seCheckboxLabel {
+        @extend .dg_label;
+        @extend .dg_checkbox-label;
+      }
+
+      .seRadio {
+        @extend .dg_radio-input;
+      }
+
+      .seCheckbox {
+        @extend .dg_checkbox-input;
+      }
+
+      input[type="submit"] {
+        @extend .dg_button;
+      }
+
+      input[type="reset"] {
+        @extend .dg_button-link;
+      }
+    }
+
+    .seLabelCell {
+      @extend .dg_fieldset-hint;
     }
   }
 }

--- a/src/styles/partials/components/_checkbox.scss
+++ b/src/styles/partials/components/_checkbox.scss
@@ -14,7 +14,6 @@ $checkbox-size: 40px;
   .dg_checkbox-input {
     cursor: pointer;
     position: absolute;
-    z-index: 1;
     top: -2px;
     left: -2px;
     width: 44px;

--- a/src/styles/partials/components/_checkbox.scss
+++ b/src/styles/partials/components/_checkbox.scss
@@ -1,122 +1,121 @@
 .dg_checkbox,
 .dg_radio {
-	line-height: 1.25;
-	display: block;
-	position: relative;
-	min-height: 40px;
-	margin-bottom: 10px;
-	padding-left: 40px;
-	clear: left;
+  line-height: 1.25;
+  display: block;
+  position: relative;
+  min-height: 40px;
+  margin-bottom: 10px;
+  padding-left: 40px;
+  clear: left;
 
-	.dg_radio-input,
-	.dg_checkbox-input {
-		cursor: pointer;
-		position: absolute;
-		z-index: 1;
-		top: -2px;
-		left: -2px;
-		width: 44px;
-		height: 44px;
-		margin: 0;
-		opacity: 0;
+  .dg_radio-input,
+  .dg_checkbox-input {
+    cursor: pointer;
+    position: absolute;
+    z-index: 1;
+    top: -2px;
+    left: -2px;
+    width: 44px;
+    height: 44px;
+    margin: 0;
+    opacity: 0;
 
-		&:checked + .dg_checkbox-label::after,
-		&:checked + .dg_radio-label::after {
-			opacity: 1;
-		}
+    &:checked + .dg_checkbox-label::after,
+    &:checked + .dg_radio-label::after {
+      opacity: 1;
+    }
 
-		&:disabled,
-		&:disabled + .dg_checkbox-label,
-		&:disabled + .dg_radio-label {
-			cursor: default;
-		}
+    &:disabled,
+    &:disabled + .dg_checkbox-label,
+    &:disabled + .dg_radio-label {
+      cursor: default;
+    }
 
-		&:disabled + .dg_checkbox-label,
-		&:disabled + .dg_radio-label {
-			opacity: .5;
-		}
-	}
+    &:disabled + .dg_checkbox-label,
+    &:disabled + .dg_radio-label {
+      opacity: 0.5;
+    }
+  }
 
-	input[type="checkbox" i] {
-		background-color: initial;
-		cursor: default;
-		-webkit-appearance: checkbox;
-		box-sizing: border-box;
-		margin: 3px 3px 3px 4px;
-		padding: initial;
-		border: initial;
-	}
+  input[type="checkbox" i] {
+    background-color: initial;
+    cursor: default;
+    -webkit-appearance: checkbox;
+    box-sizing: border-box;
+    margin: 3px 3px 3px 4px;
+    padding: initial;
+    border: initial;
+  }
 
-	.dg_radio-label,
-	.dg_checkbox-label {
-		display: inline-block;
-		margin-bottom: 0;
-		padding: $padding-small $default-padding $padding-smallest;
-		cursor: pointer;
-		-ms-touch-action: manipulation;
-		touch-action: manipulation;
-	}
+  .dg_radio-label,
+  .dg_checkbox-label {
+    display: block;
+    font-family: $default-heading-font;
+    font-weight: $font-light;
+    display: block;
+    padding: $padding-small $default-padding $padding-smallest;
+  }
 
-	.dg_checkbox-label,
-	.dg_radio-label {
-		&::before {
-			content: "";
-			-webkit-box-sizing: border-box;
-			box-sizing: border-box;
-			position: absolute;
-			top: 0;
-			left: 0;
-			width: 40px;
-			height: 40px;
-			border: 2px solid $black;
-			background: transparent;
-		}
+  .dg_checkbox-label,
+  .dg_radio-label {
+    &::before {
+      content: "";
+      -webkit-box-sizing: border-box;
+      box-sizing: border-box;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 40px;
+      height: 40px;
+      border: 2px solid $black;
+      background: transparent;
+    }
 
-		&::after {
-			position: absolute;
-			opacity: 0;
-		}
-	}
+    &::after {
+      position: absolute;
+      opacity: 0;
+    }
+  }
 
-	.dg_checkbox-label {
-		&::after {
-			position: absolute;
-			top: 8px;
-			left: 11px;
-			top: 3px;
-			left: 6px;
-			content: "\F00C"; /* check - solid - https://fontawesome.com/icons/check?style=solid*/
-			font-family: $font-awesome-pro;
-			font-size: 28px;
-		}
-	}
+  .dg_checkbox-label {
+    &::after {
+      position: absolute;
+      top: 8px;
+      left: 11px;
+      top: 3px;
+      left: 6px;
+      content: "\F00C"; /* check - solid - https://fontawesome.com/icons/check?style=solid*/
+      font-family: $font-awesome-pro;
+      font-size: 28px;
+    }
+  }
 
-	.dg_radio-label {
-		&::before {
-			border-radius: 50%;
-		}
+  .dg_radio-label {
+    &::before {
+      border-radius: 50%;
+    }
 
-		&::after {
-			content: '';
-			top: 7px;
-			left: 7px;
-			border: 13px solid $black;
-			border-radius: 50%;
-		}
-	}
+    &::after {
+      content: "";
+      top: 7px;
+      left: 7px;
+      border: 13px solid $black;
+      border-radius: 50%;
+    }
+  }
 }
 
 $circle-focus: 0 0 0 3px $white, 0 0 0 5px $blue-lightest;
 
 input[type="radio"] {
-	&:focus + label:before {
-		-webkit-box-shadow: $circle-focus;
-		box-shadow: $circle-focus;
-	}
+  &:focus + label:before {
+    -webkit-box-shadow: $circle-focus;
+    box-shadow: $circle-focus;
+  }
 }
 
 input[type="checkbox"] {
-	&:focus + label:before {
-		@extend :focus;
-	}
+  &:focus + label:before {
+    @extend :focus;
+  }
 }

--- a/src/styles/partials/components/_checkbox.scss
+++ b/src/styles/partials/components/_checkbox.scss
@@ -1,11 +1,13 @@
+$checkbox-size: 40px;
+
 .dg_checkbox,
 .dg_radio {
   line-height: 1.25;
   display: block;
   position: relative;
-  min-height: 40px;
-  margin-bottom: 10px;
-  padding-left: 40px;
+  min-height: $checkbox-size;
+  margin-bottom: $margin-small;
+  padding-left: $padding-largest;
   clear: left;
 
   .dg_radio-input,
@@ -65,9 +67,9 @@
       position: absolute;
       top: 0;
       left: 0;
-      width: 40px;
-      height: 40px;
-      border: 2px solid $black;
+      width: $checkbox-size;
+      height: $checkbox-size;
+      border: $default-border-width solid $black;
       background: transparent;
     }
 
@@ -86,7 +88,7 @@
       left: 6px;
       content: "\F00C"; /* check - solid - https://fontawesome.com/icons/check?style=solid*/
       font-family: $font-awesome-pro;
-      font-size: 28px;
+      font-size: $deck-font-size;
     }
   }
 

--- a/src/styles/partials/components/_checkbox.scss
+++ b/src/styles/partials/components/_checkbox.scss
@@ -86,7 +86,7 @@ $checkbox-size: 40px;
       left: 11px;
       top: 3px;
       left: 6px;
-      content: "\F00C"; /* check - solid - https://fontawesome.com/icons/check?style=solid*/
+      content: $icon-check;
       font-family: $font-awesome-pro;
       font-size: $deck-font-size;
     }

--- a/src/styles/partials/components/_fieldset.scss
+++ b/src/styles/partials/components/_fieldset.scss
@@ -1,32 +1,29 @@
 .dg_fieldset {
-	border-top: $border-width-large solid $gray-light;
-	margin-bottom: $margin-largest;
-	padding-top: $padding-large;
+  border-top: $border-width-large solid $gray-light;
+  margin-bottom: $margin-larger;
+  padding-top: $padding-large;
 
-	.dg_fieldset-hint {
-		display: block;
-		font-family: $default-heading-font;
-		font-weight: $font-light;
-		margin-bottom: $margin-large;
-		margin-top: $margin-smallest;
-	}
+  .dg_form-field {
+    padding-top: $padding-largest;
+  }
 
-	.dg_form-field {
-		padding-top: $padding-largest;
-	}
+  .dg_fieldset-hint {
+    display: block;
+    margin-bottom: $default-margin;
+  }
 
-	.dg_legend {
-		border: none;
-		color: $gray-dark;
-		float: left;
-		font-family: $default-heading-font;
-		font-size: $smallest-heading-font-size;
-		font-weight: $font-bold;
-		letter-spacing: 10px;
-		margin-bottom: $margin-large;
-		margin-top: $margin-smallest;
-		padding-bottom: $padding-small;
-		text-transform: uppercase;
-		width: 100%;
-	}
+  .dg_legend {
+    border: none;
+    color: $gray-dark;
+    float: left;
+    font-family: $default-heading-font;
+    font-size: $smallest-heading-font-size;
+    font-weight: $font-bold;
+    letter-spacing: 10px;
+    margin-bottom: $default-margin;
+    margin-top: $margin-smallest;
+    padding-bottom: $padding-small;
+    text-transform: uppercase;
+    width: 100%;
+  }
 }

--- a/src/styles/partials/components/_form.scss
+++ b/src/styles/partials/components/_form.scss
@@ -1,4 +1,6 @@
 .dg_form-field {
+  margin-bottom: $default-margin;
+
   input,
   label,
   label > span {

--- a/src/styles/variables/_icons.scss
+++ b/src/styles/variables/_icons.scss
@@ -7,6 +7,8 @@ $smallest-icon-size: 0.5em;
 /* uses far fa-chevron- */
 $icon-arrow-down: "\f078";
 $icon-arrow-right: "\f054";
-$icon-home: "\f015";
 $icon-asterisk: "\f069";
+$icon-check: "\F00C";
+$icon-home: "\f015";
+
 $icon-arrow-default-size: 24px;

--- a/src/styles/variables/_icons.scss
+++ b/src/styles/variables/_icons.scss
@@ -8,4 +8,5 @@ $smallest-icon-size: 0.5em;
 $icon-arrow-down: "\f078";
 $icon-arrow-right: "\f054";
 $icon-home: "\f015";
+$icon-asterisk: "\f069";
 $icon-arrow-default-size: 24px;


### PR DESCRIPTION
These styles override the existing Site Executive default styles. They make it so forms created with site executive match that of the design system.