### PR TITLE
Adjsuted images per design with se kept in mind

### DIFF
--- a/src/styles/partials/components/_images.scss
+++ b/src/styles/partials/components/_images.scss
@@ -1,4 +1,8 @@
-/* Handle images inside the main content section */
+/*
+    Handle images inside the main content section.
+    !important is used throughout the file to override the site executive feature of setting images width and height.
+    We want images to display to their natural size, and respond as screens become smaller.
+*/
 #dg_main-content {
   img,
   .dg_image {
@@ -9,6 +13,7 @@
   .dg_image {
     display: block;
     position: relative;
+
     height: auto !important;
     width: auto !important;
 

--- a/src/styles/partials/components/_images.scss
+++ b/src/styles/partials/components/_images.scss
@@ -1,49 +1,49 @@
 /* Handle images inside the main content section */
 #dg_main-content {
-  img {
-    width: 100%;
-    margin-bottom: $padding-largest;
-  }
-}
-
-.dg_image {
-  display: block;
-  position: relative;
-  height: auto !important;
-  width: auto !important;
-  max-width: 50%;
-
-  &.left,
-  &.right {
-    margin-top: $margin-small;
+  img,
+  .dg_image {
+    max-width: 100%;
     margin-bottom: $padding-largest;
   }
 
-  &.left {
-    float: left;
-    margin-right: $padding-largest;
-  }
+  .dg_image {
+    display: block;
+    position: relative;
+    height: auto !important;
+    width: auto !important;
 
-  &.right {
-    float: right;
-    margin-left: $padding-largest;
+    &.left,
+    &.right {
+      max-width: 50% !important;
+      margin-top: $margin-small;
+      margin-bottom: $padding-largest;
+    }
+
+    &.left {
+      float: left;
+      margin-right: $padding-largest;
+    }
+
+    &.right {
+      float: right;
+      margin-left: $padding-largest;
+    }
   }
 }
 
 @media screen and (max-width: $medium-breakpoint) {
-  .dg_image {
+  #dg_main-content .dg_image {
     &.left,
     &.right {
       float: none;
-      max-width: 100%;
+      max-width: 100% !important;
       margin: auto;
     }
   }
 }
 
 @media screen and (max-width: $small-breakpoint) {
-  .dg_image {
-    max-width: 100%;
-    width: 100%;
+  #dg_main-content .dg_image {
+    width: 100% !important;
   }
 }


### PR DESCRIPTION
During the demo we discovered taht the images still weren't working. That's because we only targeted floated images and some of the rules didn't apply because they were not in the main container. This addresses these issues based on feedback from design.

The nice 100% images we had, will require a little more work for the designers as they will need to ensure images are larger than there target containers to be 100% width