### PR TITLE
Bug#15869-Summary List Icons do not align with Headings

### DIFF
--- a/src/styles/partials/components/_summary-list.scss
+++ b/src/styles/partials/components/_summary-list.scss
@@ -28,6 +28,15 @@
     justify-content: flex-start;
     align-items: flex-start;
     margin-bottom: $default-margin;
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin-top: 0px;
+    }
+
 
     p {
       color: $gray;

--- a/src/styles/partials/components/_summary-list.scss
+++ b/src/styles/partials/components/_summary-list.scss
@@ -28,15 +28,6 @@
     justify-content: flex-start;
     align-items: flex-start;
     margin-bottom: $default-margin;
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      margin-top: 0px;
-    }
-
 
     p {
       color: $gray;

--- a/src/styles/partials/template/_sidebar.scss
+++ b/src/styles/partials/template/_sidebar.scss
@@ -16,7 +16,7 @@
   p {
     font-family: $default-heading-font;
     font-size: $smallest-heading-font-size;
-    margin: $default-margin 0;
+    margin: 0 0 $default-margin 0;
   }
 
   h2 {
@@ -24,6 +24,7 @@
     letter-spacing: 10px;
     font-weight: $font-bold;
     font-size: $small-heading-font-size;
+    padding-top: $padding-large;
   }
 
   p {


### PR DESCRIPTION
This bug is dg_sidebar__section h3 has top margin 20px. That is why align was not correct . Override the margin-top on .dg_sidebar__section to fix this issue