### PR TITLE
Contact us H2 Color is Incorrect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.80",
+  "version": "0.1.84",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.84",
+  "version": "0.1.86",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/partials/template/_sidebar.scss
+++ b/src/styles/partials/template/_sidebar.scss
@@ -21,6 +21,7 @@
 
   h2 {
     border: none;
+    color: $gray-dark;
     letter-spacing: 10px;
     font-weight: $font-bold;
     font-size: $small-heading-font-size;


### PR DESCRIPTION
This pull request addresses bug [15275](https://oittfs.bcg.ad.bcgov.us/BAUCollection/BaltimoreCounty.Gov%20Website/_workitems/edit/15275). One line update, specified H2 color to be `$gray-dark`.

I believe the XD document listed in the bug is outdated. A more up-to-date XD document can be found [here](https://xd.adobe.com/view/5e59f202-fe25-433e-4697-230f34045cd2-2868/screen/24567880-c354-4133-bf90-6ff9fbbb345f/Subpage).