### PR TITLE
Bug 15812

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.80",
+  "version": "0.1.85",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -47,7 +47,7 @@
     text-align: left;
     font-size: $smallest-heading-font-size;
     font-weight: $font-medium;
-    padding: $default-padding;
+    padding: $default-padding 0px;
     letter-spacing: 0;
     color: $gray-dark;
     text-transform: none;

--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -1,6 +1,6 @@
 .dg_accordion {
   text-align: right;
-  margin: $default-margin;
+  margin: $default-margin 0px;
 
   p,
   ul {
@@ -47,7 +47,7 @@
     text-align: left;
     font-size: $smallest-heading-font-size;
     font-weight: $font-medium;
-    padding: $default-padding 0px;
+    padding: $default-padding;
     letter-spacing: 0;
     color: $gray-dark;
     text-transform: none;


### PR DESCRIPTION
This references bug 15812. Removed the left margin on the` .dg_accordion `class. Also inferring the right should be removed as well, so the accordion extends the full frame and lines up evenly with content above and below it.

@martypowell @sdurphy 