### PR TITLE
Bug#15952

### DIFF
--- a/src/styles/partials/components/_site-nav.scss
+++ b/src/styles/partials/components/_site-nav.scss
@@ -72,7 +72,7 @@ $mobile-menu-width: 245px;
 
         i {
           text-align: center;
-          margin-right: $margin-small;
+          margin-right: $margin-small + $base-spacing-unit;
           width: 40px;
           font-size: $icon-site-nav-default-size;
         }

--- a/src/styles/partials/components/_site-nav.scss
+++ b/src/styles/partials/components/_site-nav.scss
@@ -72,7 +72,7 @@ $mobile-menu-width: 245px;
 
         i {
           text-align: center;
-          margin-right: $margin-small + $base-spacing-unit;
+          margin-right: $default-margin;
           width: 40px;
           font-size: $icon-site-nav-default-size;
         }


### PR DESCRIPTION
According to Sam, the spacing between the global navigation menu list item icon and the text should be 20px. It is currently 15px. Added 5px in margin and that should give 20px