### PR TITLE
Added 100% width to the class dg_date-news-card.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-<<<<<<< HEAD
-  "version": "0.1.85",
-=======
-  "version": "0.1.86",
->>>>>>> integration
+  "version": "0.1.91",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/partials/components/_date-news-card.scss
+++ b/src/styles/partials/components/_date-news-card.scss
@@ -3,6 +3,7 @@
   display: block;
   padding: $padding-larger;
   text-decoration: none;
+  width: 100%;
 
   p {
     margin-bottom: 0;


### PR DESCRIPTION
This fix addresses bug [16183](https://oittfs.bcg.ad.bcgov.us/BAUCollection/BaltimoreCounty.Gov%20Website/_workitems/edit/16183). Adds `width: 100%;` to the class `.dg_date-news-card` ensuring a consistent display on mobile.