### PR TITLE
Bug -1853

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/overrides/_google-search-results.scss
+++ b/src/styles/overrides/_google-search-results.scss
@@ -136,3 +136,16 @@
   background: none !important;
   border: none !important;
 }
+
+@media screen and (max-width: $medium-breakpoint) {
+  .gsc-results {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+
+    .gsc-cursor-box .gsc-cursor-page {
+      margin: 0px;
+      padding: $base-spacing-unit;
+    }
+  }
+}


### PR DESCRIPTION
This addresses bug [15853](https://oittfs.bcg.ad.bcgov.us/BAUCollection/BaltimoreCounty.Gov%20Website/_workitems/edit/15853). Added styling to prevent the text from expanding out of frame on mobile. Unsure how to provide a sample to render, as the components page doesn't display the search results page.