### PR TITLE
Bug 16471 Newsroom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/partials/components/_card-container.scss
+++ b/src/styles/partials/components/_card-container.scss
@@ -18,6 +18,11 @@
       margin-bottom: $default-margin;
     }
   }
+  .dg_card__footer {
+    .dg_button {
+      display: inline-block;
+    }
+  }
 }
 .dg_icon-container {
   color: $gold;

--- a/src/styles/partials/components/_card-container.scss
+++ b/src/styles/partials/components/_card-container.scss
@@ -17,6 +17,10 @@
       font-size: $base-font-size;
       margin-bottom: $default-margin;
     }
+    img,
+    i {
+      margin-bottom: $default-margin;
+    }
   }
   .dg_card__footer {
     .dg_button {


### PR DESCRIPTION
This PR addresses Bug 16471. There are two fixes here.

1. Adds `display: inline-block;` to .`dg_button` while it is within `.dg_card__footer`. This allows the button to achieve even spacing within its container.

2. I added `margin-bottom: 20px;` to `i` and `img` tags while children of the class `.dg_card__footer`.