### PR TITLE
Bug 16453

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/partials/components/_date-news-card.scss
+++ b/src/styles/partials/components/_date-news-card.scss
@@ -40,8 +40,9 @@
   }
 
   .dg_date-news-card__headline {
-    @extend h3;
-    font-size: $small-heading-font-size;
+    font-family: $default-heading-font;
+    font-size: $h3-font-size;
+    font-weight: $font-bold;
     margin-bottom: 0;
     text-transform: initial;
   }

--- a/src/styles/partials/components/_date-news-card.scss
+++ b/src/styles/partials/components/_date-news-card.scss
@@ -14,6 +14,17 @@
     border-bottom: $border-width-small solid $gray-light;
     display: flex;
     padding-bottom: $padding-large;
+
+    p {
+      &.dg_date-news-card__headline {
+        font-family: $default-heading-font;
+        font-size: $h3-font-size;
+        font-weight: $font-bold;
+        margin-bottom: 0;
+        text-transform: initial;
+        -webkit-text-size-adjust: none;
+      }
+    }
   }
 
   .dg_date-news-card__date {
@@ -37,14 +48,6 @@
   .dg_date-news-card__day {
     font-size: 45px;
     line-height: 35px;
-  }
-
-  .dg_date-news-card__headline {
-    font-family: $default-heading-font;
-    font-size: $h3-font-size;
-    font-weight: $font-bold;
-    margin-bottom: 0;
-    text-transform: initial;
   }
 
   .dg_date-news-card__snippet {


### PR DESCRIPTION
This PR addresses Bug 16453. Unsure of how to test this as I cannot recreate without the use of browser stack.

1. Updated size to 20px.
2. Removed extend on .dg_date-news-card__headline. Thinking this should resolve the revolving font size issue.