### PR TITLE
Bug 16474 - Newsroom - News Cards (on Home Page) IE Issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/partials/components/_date-news-card.scss
+++ b/src/styles/partials/components/_date-news-card.scss
@@ -1,6 +1,8 @@
 .dg_date-news-card {
   border: $border-width-small solid $gray-light;
   display: block;
+  height: 100%;
+  min-height: 300px;
   padding: $padding-larger;
   text-decoration: none;
   width: 100%;


### PR DESCRIPTION
This PR addresses bug 16474.

1. Added `max-height: 300px;` and `height: 100%; `to `.dg_date-news-card`. This fixes a bug where IE doesn't calculate height in flex if there isn't a definitive height set.

2. Testing in browser stack revealed there is no longer an issue with the heading text being in all caps. This must have been inadvertently resolved with a previous PR.