### PR TITLE
Changed styles of header links inside of card containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/partials/components/_card-container.scss
+++ b/src/styles/partials/components/_card-container.scss
@@ -10,6 +10,14 @@
   text-align: center;
   width: 100%;
 
+  h1,
+  h2,
+  h3 {
+    > a {
+      text-decoration: none;
+    }
+  }
+
   .dg_card__content {
     flex: 0 0 auto;
     p,


### PR DESCRIPTION
See Search Results for the desired (existing style). Currently the would be underlined.

![image](https://user-images.githubusercontent.com/1933400/79013763-68ce7500-7b37-11ea-87d3-2b6b2cef8e99.png)
