### PR TITLE
Fixed Bottom Margin on Form "Groups"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/overrides/_se-form.scss
+++ b/src/styles/overrides/_se-form.scss
@@ -43,8 +43,13 @@
     .SEAFGroupHorizontal,
     .SEAFLabelHorizontal,
     .SEAFGroupVertical,
-    .SEAFLabelVertical {
+    .SEAFLabelVertical,
+    .SEAFWrapper {
       margin-bottom: $default-margin;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
 
     .seRequiredMarker {


### PR DESCRIPTION
We noticed some form elements were scrunched up while testing the checkbox styles.

![image](https://user-images.githubusercontent.com/1933400/79232100-1510a400-7e35-11ea-9c1e-7c46342fbfb3.png)

This pr addresses this by targeting a consistent class available around each form field. It also adds a bottom margin of the element if it's the last child.
