### PR TITLE
Added SCSS styling for hover.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/components/site/EmphasizedImage.js
+++ b/src/components/site/EmphasizedImage.js
@@ -1,16 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const EmphasizedImage = props => {
+const EmphasizedImage = (props) => {
   return (
     <div className="dg_card-image">
-      <img alt={props.imageHeader} src={props.imageSrc}></img>
-      <div className="dg_card-content">
-        <p>{props.imageHeader}</p>
-        <p>
-          <a href={props.imageLink}>{props.imageSubHeader}</a>
-        </p>
-      </div>
+      <a href={props.imageLink}>
+        <img alt={props.imageHeader} src={props.imageSrc}></img>
+        <div className="dg_card-content">
+          <p>{props.imageHeader}</p>
+          <p>{props.imageSubHeader}</p>
+        </div>
+      </a>
     </div>
   );
 };
@@ -23,7 +23,7 @@ EmphasizedImage.propTypes = {
   /** Adds a sub heading to the image */
   imageSubHeader: PropTypes.string.isRequired,
   /** Adds a link to the image */
-  imageLink: PropTypes.string.isRequired
+  imageLink: PropTypes.string.isRequired,
 };
 
 export default EmphasizedImage;

--- a/src/styles/partials/components/_emphasized-image.scss
+++ b/src/styles/partials/components/_emphasized-image.scss
@@ -16,6 +16,10 @@
           }
         }
       }
+      > img {
+        filter: grayscale(70%);
+        transition: $default-duration;
+      }
     }
   }
 }

--- a/src/styles/partials/components/_emphasized-image.scss
+++ b/src/styles/partials/components/_emphasized-image.scss
@@ -6,6 +6,18 @@
     object-fit: fill;
     width: 100%;
   }
+  a {
+    &:hover {
+      > .dg_card-content {
+        p {
+          &:last-of-type {
+            color: $vibrant-blue;
+            transition: $default-duration;
+          }
+        }
+      }
+    }
+  }
 }
 
 .dg_card-content {

--- a/src/styles/partials/components/_emphasized-image.scss
+++ b/src/styles/partials/components/_emphasized-image.scss
@@ -17,7 +17,7 @@
         }
       }
       > img {
-        filter: grayscale(70%);
+        opacity: 0.7;
         transition: $default-duration;
       }
     }


### PR DESCRIPTION
Addresses bug 16905. Adds hover styles to emphasized image, when child elements are wrapped in an a tag.