### PR TITLE
Remove default margin from sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/partials/template/_sidebar.scss
+++ b/src/styles/partials/template/_sidebar.scss
@@ -18,7 +18,6 @@
   p {
     font-family: $default-heading-font;
     font-size: $smallest-heading-font-size;
-    margin: 0 0 $default-margin 0;
   }
 
   h2 {


### PR DESCRIPTION
Default margin was causing related topics to display really large. In this case this margin wasn't affecting any of the other elements, therefore it's been removed.