### PR TITLE
Added Column Utilities for Rec Details Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/partials/components/_utilities.scss
+++ b/src/styles/partials/components/_utilities.scss
@@ -19,3 +19,21 @@
   position: static;
   width: auto;
 }
+
+.list-col-2 {
+  -webkit-column-count: 2;
+  -moz-column-count: 2;
+  column-count: 2;
+}
+
+.list-col-3 {
+  -webkit-column-count: 3;
+  -moz-column-count: 3;
+  column-count: 3;
+}
+
+.list-col-4 {
+  -webkit-column-count: 4;
+  -moz-column-count: 4;
+  column-count: 4;
+}


### PR DESCRIPTION
Created utilities for various column options for the amenities list on the parks and recs details page. This utilizes the property `column-count`. Let me know if the class name makes sense or if something else would make more sense.