### PR TITLE
Bug 17884

### DIFF
--- a/src/styles/partials/components/_summary-list.scss
+++ b/src/styles/partials/components/_summary-list.scss
@@ -35,10 +35,11 @@
   }
 
   i {
-    text-align: left;
+    text-align: center;
     font-size: $h1-font-size;
     margin-right: $default-padding;
-    width: 40px;
+    width: 45px;
+    max-width: 45px;
   }
 
   a {

--- a/src/styles/partials/components/_summary-list.scss
+++ b/src/styles/partials/components/_summary-list.scss
@@ -35,9 +35,10 @@
   }
 
   i {
-    text-align: center;
+    text-align: left;
     font-size: $h1-font-size;
     margin-right: $default-padding;
+    width: 40px;
   }
 
   a {


### PR DESCRIPTION
This fix addresses the uneven headings in the sidebar of pages, caused by inconsistent sizes of FontAwesome icons. Piggy-backed off the FontAwesome fa-fw class to address the issue, by adding a width and min-width to the i tag in the sidebar. The fix has been tested across two pages, and seems to work.