### PR TITLE
Active Class for Alt List

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/styles/partials/components/_alt-list.scss
+++ b/src/styles/partials/components/_alt-list.scss
@@ -37,6 +37,9 @@ $icon-arrow-width: 32px;
     position: relative;
     padding-right: $icon-arrow-width; /* leave space for the absolutely position icon */
     &.active {
+      &:hover:after {
+        color: $pale-blue;
+      }
       a {
         color: $pale-blue;
       }

--- a/src/styles/partials/components/_alt-list.scss
+++ b/src/styles/partials/components/_alt-list.scss
@@ -36,7 +36,15 @@ $icon-arrow-width: 32px;
     @include default-transition(color);
     position: relative;
     padding-right: $icon-arrow-width; /* leave space for the absolutely position icon */
+    &.active {
+      a {
+        color: $pale-blue;
+      }
 
+      &:after {
+        color: $pale-blue;
+      }
+    }
     &:after {
       color: $gray-light;
       @include default-transition;


### PR DESCRIPTION
Added functionality for the alt list that appears in the sidebar, with an additional .`active `class. To test this, add the class .active to the `<li>` tag. Ex. `<li class="active">`.