### PR TITLE
17884 Internet Explorer Sidebar Overlap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/styles/partials/components/_summary-list.scss
+++ b/src/styles/partials/components/_summary-list.scss
@@ -25,6 +25,9 @@
     align-items: flex-start;
     margin-bottom: $default-margin;
 
+    div {
+      width: 100%; /*This addresses a flex bug in IE that requires width to be specified*/
+    }
     p {
       color: $gray;
     }


### PR DESCRIPTION
This fix addresses a bug in IE, where the icon and `div `container overlap. This is a known bug when using `flex `in IE and is solved by declaring a `width `property on the child elements. To accomplish this, I added a `width `property to the `div` element within the class `..dg_summary-list__item`. One line code update, but please test using inspect element within IE for confirmation.