### PR TITLE
Added plus icon on collapse medium screens

### DIFF
--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -102,3 +102,13 @@
 .show {
   display: block;
 }
+
+@media screen and (max-width: $medium-breakpoint) {
+  .dg_accordion__collapsible {
+    .dg_accordion-btn {
+      &:after {
+        @include icon-content($icon-plus);
+      }
+    }
+  }
+}

--- a/src/styles/variables/_icons.scss
+++ b/src/styles/variables/_icons.scss
@@ -24,4 +24,4 @@ $icon-register: "\f234";
 $icon-email: "\f0e0";
 $icon-twitter: "\f099";
 $icon-facebook: "\f082";
-$icon-plus: "\f067"
+$icon-plus: "\f067";

--- a/src/styles/variables/_icons.scss
+++ b/src/styles/variables/_icons.scss
@@ -24,3 +24,4 @@ $icon-register: "\f234";
 $icon-email: "\f0e0";
 $icon-twitter: "\f099";
 $icon-facebook: "\f082";
+$icon-plus: "\f067"


### PR DESCRIPTION
Added a medium screen check to change the arrow icon to a plus icon for the collapse component.