### PR TITLE
Site Search - Search Icon Overlaps Input Field at MD, SM, XS Breakpoints

### DIFF
--- a/src/styles/partials/components/_site-header.scss
+++ b/src/styles/partials/components/_site-header.scss
@@ -54,6 +54,10 @@ $header-height: 65px;
     justify-content: center;
   }
 
+  .dg_search-container {
+    margin-right: 0px;
+  }
+
   .dg_site-header {
     background: $white;
     position: relative;


### PR DESCRIPTION
Removing the padding at smaller breakpoints appears to resolve this issue. The field is no longer squished due to this and extends evenly left to right.