### PR TITLE
removed hidden prop from a required field

### DIFF
--- a/src/styles/overrides/_se-form.scss
+++ b/src/styles/overrides/_se-form.scss
@@ -63,7 +63,6 @@
       font-size: 0;
       font-weight: $font-medium;
       position: relative;
-      visibility: hidden;
 
       &:after {
         @include icon-content($icon-asterisk);


### PR DESCRIPTION
This hidden property was preventing ie from displaying this red *. Im not honestly sure why we did it this way. It appears we hide the icon until we include the icon then we unhide it.....so I deleted that. Not sure what the point of that was but maybe Im missing something. Thankfully we have code reviews.