### PR TITLE
added fix for Bug #16014 Text Filter Placeholder Text in Montserrat in IE

### DIFF
--- a/src/styles/partials/components/_search.scss
+++ b/src/styles/partials/components/_search.scss
@@ -23,3 +23,6 @@
   font-family: $default-heading-font;
   width: 100%;
 }
+.dg_form-field_input--text {
+  font-family: $default-body-font;
+}


### PR DESCRIPTION
Change font-family to display Crimson Text for this search text