### PR TITLE
20302 accordion update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -52,7 +52,7 @@
   .dg_accordion__subheader {
     font-size: $smallest-heading-font-size;
     font-weight: $font-medium;
-    color: #ffffff;
+    color: $white;
     margin-left: $margin-largest;
     padding-top: $padding-small;
     text-transform: none;
@@ -66,12 +66,12 @@
     letter-spacing: 0;
     color: $gray-dark;
     text-transform: none;
-    border: $border-width-small solid #002278;
+    border: $border-width-small solid $blue;
   }
 
   .dg_accordion-btn {
-    background-color: #002280;
-    color: #ffffff;
+    background-color: $blue;
+    color: $white;
     position: relative;
     padding-top: $padding-large;
     padding-bottom: $padding-large;
@@ -84,7 +84,7 @@
     font-weight: $font-bold;
     cursor: pointer;
 &:hover {
-  background-color: #1076bc;
+  background-color: $vibrant-blue;
 }
     &:focus {
       outline: none;

--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -36,7 +36,7 @@
   }
 
   .dg_accordion_buttontext-holder {
-    margin-left: 50px;
+    margin-left: $margin-largest;
   }
 
   h1,
@@ -53,7 +53,7 @@
     font-size: $smallest-heading-font-size;
     font-weight: $font-medium;
     color: #ffffff;
-    margin-left: 50px;
+    margin-left: $margin-largest;
     padding-top: $padding-small;
     text-transform: none;
   }

--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -25,7 +25,7 @@
   font-size: $h2-font-size;
   font-weight: $font-bold;
   width: 100%;
-  border-top: $border-width-small $gray solid;
+  margin-bottom: $border-width-small;
 
   &:last-child {
     border-bottom: $border-width-small $gray solid;
@@ -66,6 +66,7 @@
     letter-spacing: 0;
     color: $gray-dark;
     text-transform: none;
+    border: $border-width-small solid #002278;
   }
 
   .dg_accordion-btn {

--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -83,9 +83,9 @@
     font-size: $small-heading-font-size;
     font-weight: $font-bold;
     cursor: pointer;
-&:hover {
-  background-color: $vibrant-blue;
-}
+    &:hover {
+      background-color: $vibrant-blue;
+    }
     &:focus {
       outline: none;
     }
@@ -121,20 +121,4 @@
 
 .show {
   display: block;
-}
-
-@media screen and (max-width: $small-breakpoint) {
-  .dg_collapse.dg_accordion__collapsible.collapsed .dg_accordion-btn {
-    &:after {
-      @include icon-content($icon-plus);
-    }
-  }
-
-  .dg_collapse.dg_accordion__collapsible {
-    .dg_accordion-btn {
-      &:after {
-        @include icon-content($icon-minus);
-      }
-    }
-  }
 }

--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -48,7 +48,7 @@
   .dg_accordion__subheader {
     font-size: $smallest-heading-font-size;
     font-weight: $font-medium;
-    color: $gray-dark;
+    color: #ffffff;
     padding-top: $padding-small;
     text-transform: none;
   }
@@ -64,6 +64,8 @@
   }
 
   .dg_accordion-btn {
+    background-color: #002280;
+    color: #ffffff;
     position: relative;
     padding-top: $padding-large;
     padding-bottom: $padding-small;
@@ -86,23 +88,23 @@
       }
     }
 
-    &:after {
+    &:before {
       position: absolute;
       padding-top: $padding-small;
       padding-bottom: $padding-small;
       font-size: $icon-arrow-default-size;
-      @include icon-content($icon-arrow-down);
+      @include icon-content($icon-minus);
       top: $padding-small;
-      right: 0;
+      left: 0;
     }
   }
 }
 
-.collapsed .dg_accordion-btn::after {
+.collapsed .dg_accordion-btn::before {
   position: absolute;
   font-size: $icon-arrow-default-size;
   cursor: pointer;
-  @include icon-content($icon-arrow-right);
+  @include icon-content($icon-plus);
 }
 
 .collapse {

--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -35,6 +35,10 @@
     color: $vibrant-blue;
   }
 
+  .dg_accordion_buttontext-holder {
+    margin-left: 50px;
+  }
+
   h1,
   h2,
   h3,
@@ -43,7 +47,6 @@
   h6 {
     color: inherit;
     margin-bottom: 0px;
-    margin-left: 50px;
   }
 
   .dg_accordion__subheader {
@@ -96,8 +99,8 @@
       padding-bottom: $padding-small;
       font-size: $icon-arrow-default-size;
       @include icon-content($icon-minus);
-      top: $padding-small;
-      left: 0;
+      top: 7px;
+      left: $padding-large;
     }
   }
 }

--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -83,7 +83,9 @@
     font-size: $small-heading-font-size;
     font-weight: $font-bold;
     cursor: pointer;
-
+&:hover {
+  background-color: #1076bc;
+}
     &:focus {
       outline: none;
     }

--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -43,12 +43,14 @@
   h6 {
     color: inherit;
     margin-bottom: 0px;
+    margin-left: 50px;
   }
 
   .dg_accordion__subheader {
     font-size: $smallest-heading-font-size;
     font-weight: $font-medium;
     color: #ffffff;
+    margin-left: 50px;
     padding-top: $padding-small;
     text-transform: none;
   }
@@ -68,7 +70,7 @@
     color: #ffffff;
     position: relative;
     padding-top: $padding-large;
-    padding-bottom: $padding-small;
+    padding-bottom: $padding-large;
     width: 100%;
     text-align: left;
     text-transform: uppercase;

--- a/src/styles/partials/components/_accordion.scss
+++ b/src/styles/partials/components/_accordion.scss
@@ -36,6 +36,7 @@
   }
 
   .dg_accordion_buttontext-holder {
+    display: block;
     margin-left: $margin-largest;
   }
 

--- a/src/styles/partials/components/_collapse.scss
+++ b/src/styles/partials/components/_collapse.scss
@@ -8,6 +8,7 @@
 
   .dg_accordion-item-body {
     background: $gray-lightest;
+    border: none;
     font-weight: $font-normal;
     font-family: $default-heading-font;
     font-size: $smallest-heading-font-size;
@@ -19,6 +20,7 @@
   }
 
   .dg_accordion-btn {
+    background-color: none;
     color: $black;
     margin-bottom: $margin-small;
 
@@ -27,6 +29,13 @@
       display: inline-block;
       left: 0;
       padding: 7.5px 0;
+    }
+
+    :before {
+      position: absolute;
+      font-size: $icon-arrow-default-size;
+      cursor: pointer;
+      @include icon-content($icon-caret-right);
     }
   }
 

--- a/src/styles/partials/components/_collapse.scss
+++ b/src/styles/partials/components/_collapse.scss
@@ -19,11 +19,11 @@
   }
   &.dg_accordion__collapsible {
     .dg_accordion-btn {
-      background-color: inherit;
+      background-color: transparent;
       color: $black;
       margin-bottom: $margin-small;
       &:hover {
-        background-color: inherit;
+        background-color: transparent;
       }
 
       &:before {

--- a/src/styles/partials/components/_collapse.scss
+++ b/src/styles/partials/components/_collapse.scss
@@ -5,7 +5,6 @@
   &:last-child {
     border-bottom: none;
   }
-
   .dg_accordion-item-body {
     background: $gray-lightest;
     border: none;
@@ -18,28 +17,42 @@
       }
     }
   }
+  &.dg_accordion__collapsible {
+    .dg_accordion-btn {
+      background-color: inherit;
+      color: $black;
+      margin-bottom: $margin-small;
+      &:hover {
+        background-color: inherit;
+      }
 
-  .dg_accordion-btn {
-    background-color: none;
-    color: $black;
-    margin-bottom: $margin-small;
+      &:before {
+        content: none;
+      }
 
-    &:after {
-      color: $blue;
-      display: inline-block;
-      left: 0;
-      padding: 7.5px 0;
+      &:after {
+        position: absolute;
+        font-size: $icon-arrow-default-size;
+        cursor: pointer;
+        @include icon-content($icon-arrow-down);
+        color: $blue;
+        display: inline-block;
+        left: 0;
+        padding: 7.5px 0;
+        top: 10px;
+      }
     }
 
-    :before {
-      position: absolute;
-      font-size: $icon-arrow-default-size;
-      cursor: pointer;
-      @include icon-content($icon-caret-right);
+    .dg_accordion_buttontext-holder {
+      margin-left: $margin-large;
     }
   }
 
-  .dg_accordion_buttontext-holder {
-    margin-left: $margin-large;
+  &.collapsed {
+    .dg_accordion-btn {
+      &:after {
+        @include icon-content($icon-arrow-right);
+      }
+    }
   }
 }


### PR DESCRIPTION
Updated the accordion styling. This updates the accordion to have a blue background, white text and a plus sign instead of an arrow. In addition, re-nested properties from the Collapse component that were dependent on the Accordion component file. This is in QA queue and currently awaiting review there as well.