### PR TITLE
Updates calc property to properly use scss variable

### DIFF
--- a/src/styles/partials/components/_card-container-leadership.scss
+++ b/src/styles/partials/components/_card-container-leadership.scss
@@ -3,8 +3,8 @@
   border: $border-width-small solid $gray;
   display: flex;
   flex-direction: column;
-  height: calc(100% - $margin-large);
-  height: expression(100% - $margin-large); //IE11 Fallback
+  height: calc(100% - #{$margin-large});
+  height: expression(100% - #{$margin-large}); //IE11 Fallback
   justify-content: flex-start;
   margin-bottom: $margin-large;
   min-height: 280px;


### PR DESCRIPTION
I realized that even though the code compiled, I wasn't using the right syntax and the scss variable was not getting compiled. 

**Original css for quick reference:**
.dg_leadership-card {
   ...
   height: calc(100% - $margin-large);
   ...
}