### PR TITLE
adds mobile style to park container

### DIFF
--- a/src/styles/partials/components/_walking-trails.scss
+++ b/src/styles/partials/components/_walking-trails.scss
@@ -319,8 +319,10 @@
     display: block;
     width: auto;
 
-    .park .health-coalition {
-      text-align: left;
+    .park {
+      .health-coalition {
+        text-align: left;
+      }
     }
   }
 }

--- a/src/styles/partials/components/_walking-trails.scss
+++ b/src/styles/partials/components/_walking-trails.scss
@@ -317,7 +317,8 @@
 
   .parks-container {
     display: block;
-    width: auto;
+    margin: 0 auto;
+    width: 100%;
 
     .park {
       .health-coalition {

--- a/src/styles/partials/components/_walking-trails.scss
+++ b/src/styles/partials/components/_walking-trails.scss
@@ -315,8 +315,13 @@
     }
   }
 
-  .parks-container .park .health-coalition {
-    text-align: left;
+  .parks-container {
+    display: block;
+    width: auto;
+
+    .park .health-coalition {
+      text-align: left;
+    }
   }
 }
 


### PR DESCRIPTION
Noticed some parks in the list were not wrapping properly on mobile, so I added some styles to force the park listings to stack on mobile instead of wrap.