### PR TITLE
22679 accepted materials

### DIFF
--- a/src/dotgov.scss
+++ b/src/dotgov.scss
@@ -40,6 +40,7 @@
 /** components */
 
 /*** header ***/
+@import "./styles/partials/components/accepted-materials";
 @import "./styles/partials/components/brand-text";
 @import "./styles/partials/components/site-status";
 @import "./styles/partials/components/site-nav";

--- a/src/styles/partials/base/_utilities.scss
+++ b/src/styles/partials/base/_utilities.scss
@@ -31,6 +31,17 @@
     display: none;
 }
 
+.sr-only {
+    border: 0;
+    clip: rect(0,0,0,0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+}
+
 .no-scroll {
     overflow-y: auto !important;
 }

--- a/src/styles/partials/components/_accepted-materials.scss
+++ b/src/styles/partials/components/_accepted-materials.scss
@@ -6,7 +6,7 @@
     }
 
     .fa-recycle {
-        color:green;
+        color: $vibrant-green;
     }
 
     .fa-trash-alt {

--- a/src/styles/partials/components/_accepted-materials.scss
+++ b/src/styles/partials/components/_accepted-materials.scss
@@ -1,7 +1,4 @@
-.accepted-materials-key {
-    border-top: $default-border-width dotted $gray-light;
-    padding-top: $padding-large;
-
+.accepted-materials-wrapper {
     .fa-ban {
         color: $red;
     }
@@ -18,11 +15,14 @@
         color: $gray;
     }
 
-    + #BACO_table_wrapper {
-        #BACO_table {
-            .fas {
-                margin-bottom: $margin-large;
-            }
+    .key {
+        border-top: $default-border-width dotted $gray-light;
+        padding-top: $padding-large;
+    }
+
+    #BACO_table {
+        .fas {
+            margin-bottom: $margin-large;
         }
     }
 }

--- a/src/styles/partials/components/_accepted-materials.scss
+++ b/src/styles/partials/components/_accepted-materials.scss
@@ -19,8 +19,10 @@
     }
 
     + #BACO_table_wrapper {
-        .fas {
-            margin-bottom: $margin-large;
+        #BACO_table {
+            .fas {
+                margin-bottom: $margin-large;
+            }
         }
     }
 }

--- a/src/styles/partials/components/_accepted-materials.scss
+++ b/src/styles/partials/components/_accepted-materials.scss
@@ -1,0 +1,25 @@
+.accepted-materials-key {
+    border-top: $default-border-width dotted $gray-light;
+
+    .fa-ban {
+        color: $red;
+    }
+
+    .fa-recycle {
+        color:green;
+    }
+
+    .fa-trash-alt {
+        color: $pale-blue;
+    }
+
+    .fa-truck {
+        color: $gray;
+    }
+}
+
+.accepted-materials-table {
+    .fa {
+        margin-bottom: $margin-large;
+    }
+}

--- a/src/styles/partials/components/_accepted-materials.scss
+++ b/src/styles/partials/components/_accepted-materials.scss
@@ -1,5 +1,6 @@
 .accepted-materials-key {
     border-top: $default-border-width dotted $gray-light;
+    padding-top: $padding-large;
 
     .fa-ban {
         color: $red;
@@ -16,10 +17,10 @@
     .fa-truck {
         color: $gray;
     }
-}
 
-.accepted-materials-table {
-    .fa {
-        margin-bottom: $margin-large;
+    + #BACO_table_wrapper {
+        .fas {
+            margin-bottom: $margin-large;
+        }
     }
 }

--- a/src/styles/variables/_colors.scss
+++ b/src/styles/variables/_colors.scss
@@ -29,6 +29,7 @@ $pale-blue-darkest: mix(black, $pale-blue, $default-lightest-ratio);
 $vibrant-blue: #1076bc;
 $purple: #3f0c62;
 $purple-light: #503b6e;
+$vibrant-green: green;
 
 /*Brand colors i.e. Twitter and Facebook*/
 $twitter-blue: #1b95e0;

--- a/src/styles/variables/_colors.scss
+++ b/src/styles/variables/_colors.scss
@@ -79,6 +79,7 @@ $colors: (
   "pale-blue--dark": $pale-blue-dark,
   "pale-blue--darkest": $pale-blue-darkest,
   "vibrant-blue": $vibrant-blue,
+  "vibrant-green": $vibrant-green,
   "gray": $gray,
   "gray--lightest": $gray-lightest,
   "gray--light": $gray-light,


### PR DESCRIPTION
Here are the original styles pulled from the head of the page for reference:

```
.fa-recycle{color:green;}
.fa-ban{color:red;}
.fa-trash-alt{color:#515477;}
.fa-truck{color:#666;}
#BACO_table .fa{margin-bottom:30px;}
.key{border-top:3px dotted #ccc;}
.sr-only {position: absolute;width: 1px;height: 1px;padding: 0;margin: -1px;overflow: hidden;clip: rect(0,0,0,0);border: 0;}
```

I moved the .sr-only class into _utilities.scss since I imagine we are/will be using this class in various parts of the site.