### PR TITLE
Duplicate Resource Blog Image Utilities

### DIFF
--- a/src/styles/partials/components/_images.scss
+++ b/src/styles/partials/components/_images.scss
@@ -18,13 +18,13 @@
   .image_right {
     border: none;
     float: right;
-    margin: 0 0 20px 20px;
+    margin: 0 0 $default-margin $default-margin;
   }
 
   .image_left {
     border: none;
     float: left;
-    margin: 0 20px 20px 0;
+    margin: 0 $default-margin $default-margin 0;
   }
 
   img,

--- a/src/styles/partials/components/_images.scss
+++ b/src/styles/partials/components/_images.scss
@@ -13,6 +13,20 @@
     }
   }
 
+  /*** This is a holdover from the previous template for the Resource blog. Please do not use this going forward. ***/
+
+  .image_right {
+    border: none;
+    float: right;
+    margin: 0 0 20px 20px;
+  }
+
+  .image_left {
+    border: none;
+    float: left;
+    margin: 0 20px 20px 0;
+  }
+
   img,
   .dg_image {
     max-width: 100%;


### PR DESCRIPTION
This moves the image utilities (image_left and image_right) into the new template, to avoid breaking existing images. I also included a brief note to ensure we use the new classes in the future and sunset the old.