### PR TITLE
Added ul to the alert property styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/dotgov-components",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "description": "UI design system for Baltimore County's primary [website](https://www.baltimorecountymd.gov).",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/styles/partials/components/_alert.scss
+++ b/src/styles/partials/components/_alert.scss
@@ -20,7 +20,8 @@
     }
   }
 
-  p {
+  p,
+  ul {
     font-size: $smallest-heading-font-size;
     margin-bottom: $margin-small;
     &:last-child {
@@ -29,7 +30,8 @@
   }
 
   p,
-  .dg_alert__status {
+  .dg_alert__status,
+  ul {
     font-family: $default-heading-font;
   }
 


### PR DESCRIPTION
This addresses Bug 22864. Nests the `<ul>` element so it inherits all the styling associated with the alert container.